### PR TITLE
feat: Support page/size for get all funders

### DIFF
--- a/src/main/java/com/yuriytkach/tracker/fundraiser/model/PagedFunders.java
+++ b/src/main/java/com/yuriytkach/tracker/fundraiser/model/PagedFunders.java
@@ -1,0 +1,19 @@
+package com.yuriytkach.tracker.fundraiser.model;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PagedFunders {
+  private final List<Funder> funders;
+  private final int page;
+  private final int size;
+  private final int total;
+
+  public static PagedFunders empty() {
+    return PagedFunders.builder().funders(List.of()).page(0).size(0).total(0).build();
+  }
+}

--- a/src/main/java/com/yuriytkach/tracker/fundraiser/rest/FundraiserStatusController.java
+++ b/src/main/java/com/yuriytkach/tracker/fundraiser/rest/FundraiserStatusController.java
@@ -81,13 +81,24 @@ public class FundraiserStatusController {
   @Produces(MediaType.APPLICATION_JSON)
   public Response funders(
     @PathParam("name") final String fundName,
-    @QueryParam("sortOrder") @DefaultValue("DESC") final SortOrder sortOrder
+    @QueryParam("sortOrder") @DefaultValue("DESC") final SortOrder sortOrder,
+    @QueryParam("page") final Integer page,
+    @QueryParam("size") final Integer size
   ) {
-    final var allFunders = trackService.getAllFunders(fundName, sortOrder);
-    log.info("Return all funders: {}", allFunders.size());
+    final var pagedFunders = trackService.getAllFunders(fundName, sortOrder, page, size);
+    log.info(
+      "Return funders: {} from page {}, size {}, total {}",
+      pagedFunders.getFunders().size(),
+      pagedFunders.getPage(),
+      pagedFunders.getSize(),
+      pagedFunders.getTotal()
+    );
     final CacheControl cacheControl = createCacheControl();
-    return addCorsHeaders(Response.ok(allFunders)
+    return addCorsHeaders(Response.ok(pagedFunders.getFunders())
       .cacheControl(cacheControl))
+      .header("x-total-count", pagedFunders.getTotal())
+      .header("x-page", pagedFunders.getPage())
+      .header("x-size", pagedFunders.getSize())
       .build();
   }
 

--- a/src/main/java/com/yuriytkach/tracker/fundraiser/service/TrackService.java
+++ b/src/main/java/com/yuriytkach/tracker/fundraiser/service/TrackService.java
@@ -1,6 +1,7 @@
 package com.yuriytkach.tracker.fundraiser.service;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -9,9 +10,9 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -20,6 +21,7 @@ import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -33,6 +35,7 @@ import com.yuriytkach.tracker.fundraiser.model.Currency;
 import com.yuriytkach.tracker.fundraiser.model.Donation;
 import com.yuriytkach.tracker.fundraiser.model.Fund;
 import com.yuriytkach.tracker.fundraiser.model.Funder;
+import com.yuriytkach.tracker.fundraiser.model.PagedFunders;
 import com.yuriytkach.tracker.fundraiser.model.SlackResponse;
 import com.yuriytkach.tracker.fundraiser.model.SortOrder;
 import com.yuriytkach.tracker.fundraiser.model.exception.DuplicateFundException;
@@ -113,17 +116,45 @@ public class TrackService {
     }
   }
 
-  public List<Funder> getAllFunders(final String fundName, final SortOrder sortOrder) {
+  public PagedFunders getAllFunders(
+    final String fundName,
+    final SortOrder sortOrder,
+    final Integer page,
+    final Integer size
+  ) {
     final Optional<Fund> fundOpt = fundService.findByName(fundName);
     if (fundOpt.isEmpty()) {
-      return List.of();
+      return PagedFunders.empty();
     }
     log.info("Getting all funders of fund: {}", fundName);
     final Comparator<Funder> fundedAtComparator = Comparator.comparing(Funder::getFundedAt);
-    return donationStorageClient.findAll(fundOpt.get().getId()).stream()
+    final Collection<Donation> foundFunders = donationStorageClient.findAll(fundOpt.get().getId());
+    final Stream<Funder> sortedFunders = foundFunders.stream()
       .map(Funder::fromDonation)
-      .sorted(sortOrder == SortOrder.ASC ? fundedAtComparator : fundedAtComparator.reversed())
-      .collect(Collectors.toUnmodifiableList());
+      .sorted(sortOrder == SortOrder.ASC ? fundedAtComparator : fundedAtComparator.reversed());
+
+    final var builder = PagedFunders.builder();
+
+    if (size == null) {
+      log.debug("Return all funders as no page/size was specified");
+      final var funders = sortedFunders.collect(toUnmodifiableList());
+      return builder.page(0)
+        .size(funders.size())
+        .total(funders.size())
+        .funders(funders)
+        .build();
+    } else {
+      final int realPage = page == null ? 0 : page;
+      log.debug("Return all funders of page: {}, with size: {}", realPage, size);
+      final int skip = size * realPage;
+      final var funders = sortedFunders.skip(skip).limit(size).collect(toUnmodifiableList());
+      return builder
+        .page(realPage)
+        .size(funders.size())
+        .total(foundFunders.size())
+        .funders(funders)
+        .build();
+    }
   }
 
   private SlackResponse processCommand(final CommandType cmd, final String cmdParamsText, final String user) {

--- a/src/test/java/com/yuriytkach/tracker/fundraiser/integration/FundStatusAwsLambdaTest.java
+++ b/src/test/java/com/yuriytkach/tracker/fundraiser/integration/FundStatusAwsLambdaTest.java
@@ -8,6 +8,7 @@ import static com.yuriytkach.tracker.fundraiser.service.dynamodb.DynamoDbDonatio
 import static com.yuriytkach.tracker.fundraiser.util.JsonMatcher.jsonEqualTo;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -231,7 +232,7 @@ public class FundStatusAwsLambdaTest implements AwsLambdaTestCommon {
 
     final var expectedFunders = SortOrder.ASC == sortOrder ? List.of(funder1, funder2) : List.of(funder2, funder1);
 
-    given()
+    final var body = given()
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .when()
@@ -241,7 +242,12 @@ public class FundStatusAwsLambdaTest implements AwsLambdaTestCommon {
       .then()
       .statusCode(200)
       .body("statusCode", equalTo(200))
-      .body("body", jsonEqualTo(expectedFunders));
+      .body("body", jsonEqualTo(expectedFunders))
+      .body("multiValueHeaders.x-page", hasItems("0"))
+      .body("multiValueHeaders.x-size", hasItems("2"))
+      .body("multiValueHeaders.x-total-count", hasItems("2"))
+      .extract().body().asString();
+    System.out.println(body);
 
     verify(fundService).findByName(FUND_NAME);
   }

--- a/src/test/java/com/yuriytkach/tracker/fundraiser/model/PagedFundersTest.java
+++ b/src/test/java/com/yuriytkach/tracker/fundraiser/model/PagedFundersTest.java
@@ -1,0 +1,23 @@
+package com.yuriytkach.tracker.fundraiser.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class PagedFundersTest {
+
+  @Test
+  void shouldReturnEmpty() {
+    assertThat(PagedFunders.empty()).isEqualTo(
+      PagedFunders.builder()
+        .funders(List.of())
+        .page(0)
+        .size(0)
+        .total(0)
+        .build()
+    );
+  }
+
+}

--- a/src/test/java/com/yuriytkach/tracker/fundraiser/service/TrackServicePatternsTest.java
+++ b/src/test/java/com/yuriytkach/tracker/fundraiser/service/TrackServicePatternsTest.java
@@ -1,0 +1,126 @@
+package com.yuriytkach.tracker.fundraiser.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.regex.Matcher;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class TrackServicePatternsTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "list, true",
+    "list fund, true",
+    "abc      hello, true",
+    "'', false"
+  })
+  void shouldMatchCommand(final String text, final boolean expected) {
+    final Matcher matcher = TrackService.CMD_PATTERN.matcher(text);
+    assertThat(matcher.matches()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "fund eur 123, true, fund, eur, 123, , ",
+    "fund eur 123 /description/, true, fund, eur, 123, description, ",
+    "fund eur 123 /description/ color, true, fund, eur, 123, description, color",
+    "fund eur 123 444, true, fund, eur, 123, , 444",
+    "fund eur 123 0xfff, true, fund, eur, 123, , 0xfff",
+    "fund eur 123 color ffff, false, , , , , ",
+    "fund-yeah eur 123, false, , , , , ",
+    "eur 123, false, , , , , ",
+    "fund eur, false, , , , , ",
+    "fund 123, false, , , , , ",
+    "teplik uah 400000 /Teplovizor/ green, true, teplik, uah, 400000, Teplovizor, green"
+  })
+  void shouldMatchCreateCommand(
+    final String text,
+    final boolean expected,
+    final String expectedFund,
+    final String expectedCurr,
+    final String expectedAmt,
+    final String expectedDesc,
+    final String expectedColor
+  ) {
+    final Matcher matcher = TrackService.CREATE_PATTERN.matcher(text);
+    assertThat(matcher.matches()).isEqualTo(expected);
+
+    if (expected) {
+      assertThat(matcher.group("name")).isEqualTo(expectedFund);
+      assertThat(matcher.group("curr")).isEqualTo(expectedCurr);
+      assertThat(matcher.group("goal")).isEqualTo(expectedAmt);
+      assertThat(matcher.group("desc")).isEqualTo(expectedDesc);
+      assertThat(matcher.group("color")).isEqualTo(expectedColor);
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'', true",
+    "fund, true",
+    "'  ', false"
+  })
+  void shouldMatchListCommand(final String text, final boolean expected) {
+    final Matcher matcher = TrackService.LIST_PATTERN.matcher(text);
+    assertThat(matcher.matches()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'', false",
+    "fund, true",
+    "'  ', false"
+  })
+  void shouldMatchDeleteCommand(final String text, final boolean expected) {
+    final Matcher matcher = TrackService.DELETE_PATTERN.matcher(text);
+    assertThat(matcher.matches()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "fund UAH 123, true",
+    "fund UAH 123 person, true",
+    "fund UAH 123 person 2022-05-06 12:13, true",
+    "fund UAH 123 person 12:13, true",
+    "fund UAH 123 2022-05-06 12:13, true",
+    "fund UAH 123 12:13, true",
+    "UAH 123 person, false",
+    "UAH 123, false",
+    "fund us 123, false",
+    "fund usd abc, false",
+    "fund usd123, false"
+  })
+  void shouldMatchTrackCommand(final String text, final boolean expected) {
+    final Matcher matcher = TrackService.TRACK_PATTERN.matcher(text);
+    assertThat(matcher.matches()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "2022-02-01 05:03, 2022-02-01T05:03:00",
+    "2022-02-01 15:13, 2022-02-01T15:13:00"
+  })
+  void shouldParseDateAndTime(final String text, final LocalDateTime expected) {
+    final var parsed = TrackService.DATE_TIME_FORMATTER.parse(text);
+    final var dateTime = LocalDateTime.from(parsed);
+
+    assertThat(dateTime).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "05:03, 05:03:00",
+    "15:13, 15:13:00"
+  })
+  void shouldParseTimeOnly(final String text, final LocalTime expected) {
+    final var parsed = TrackService.DATE_TIME_FORMATTER_ONLY_TIME.parse(text);
+    final var time = LocalTime.from(parsed);
+
+    assertThat(time).isEqualTo(expected);
+  }
+
+}

--- a/src/test/java/com/yuriytkach/tracker/fundraiser/service/TrackServiceTest.java
+++ b/src/test/java/com/yuriytkach/tracker/fundraiser/service/TrackServiceTest.java
@@ -1,126 +1,156 @@
 package com.yuriytkach.tracker.fundraiser.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.regex.Matcher;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.yuriytkach.tracker.fundraiser.config.FundTrackerConfig;
+import com.yuriytkach.tracker.fundraiser.forex.ForexService;
+import com.yuriytkach.tracker.fundraiser.model.Currency;
+import com.yuriytkach.tracker.fundraiser.model.Donation;
+import com.yuriytkach.tracker.fundraiser.model.Fund;
+import com.yuriytkach.tracker.fundraiser.model.Funder;
+import com.yuriytkach.tracker.fundraiser.model.PagedFunders;
+import com.yuriytkach.tracker.fundraiser.model.SortOrder;
+
+@ExtendWith(MockitoExtension.class)
 class TrackServiceTest {
 
-  @ParameterizedTest
-  @CsvSource({
-    "list, true",
-    "list fund, true",
-    "abc      hello, true",
-    "'', false"
-  })
-  void shouldMatchCommand(final String text, final boolean expected) {
-    final Matcher matcher = TrackService.CMD_PATTERN.matcher(text);
-    assertThat(matcher.matches()).isEqualTo(expected);
+  private static final String FUND_NAME = "fund";
+  private static final String FUND_ID = "fundId";
+
+  private static final Donation DONATION_1 = Donation.builder()
+    .amount(10)
+    .currency(Currency.UAH)
+    .dateTime(Instant.now().minusSeconds(60))
+    .person("person1")
+    .build();
+
+  private static final Donation DONATION_2 = Donation.builder()
+    .amount(20)
+    .currency(Currency.USD)
+    .dateTime(Instant.now())
+    .person("person2")
+    .build();
+
+  @Mock
+  DonationStorageClient donationStorageClient;
+
+  @Mock
+  FundService fundService;
+
+  @Mock
+  IdGenerator idGenerator;
+
+  @Mock
+  ForexService forexService;
+
+  @Mock
+  FundTrackerConfig config;
+
+  @InjectMocks
+  TrackService tested;
+
+  @Test
+  void shouldReturnEmptyFundersIfFundNotFound() {
+    when(fundService.findByName(any())).thenReturn(Optional.empty());
+
+    final var result = tested.getAllFunders(FUND_NAME, SortOrder.DESC, 0, 2);
+
+    assertThat(result).isEqualTo(PagedFunders.empty());
+
+    verify(fundService).findByName(FUND_NAME);
+    verifyNoInteractions(donationStorageClient);
   }
 
   @ParameterizedTest
-  @CsvSource({
-    "fund eur 123, true, fund, eur, 123, , ",
-    "fund eur 123 /description/, true, fund, eur, 123, description, ",
-    "fund eur 123 /description/ color, true, fund, eur, 123, description, color",
-    "fund eur 123 444, true, fund, eur, 123, , 444",
-    "fund eur 123 0xfff, true, fund, eur, 123, , 0xfff",
-    "fund eur 123 color ffff, false, , , , , ",
-    "fund-yeah eur 123, false, , , , , ",
-    "eur 123, false, , , , , ",
-    "fund eur, false, , , , , ",
-    "fund 123, false, , , , , ",
-    "teplik uah 400000 /Teplovizor/ green, true, teplik, uah, 400000, Teplovizor, green"
-  })
-  void shouldMatchCreateCommand(
-    final String text,
-    final boolean expected,
-    final String expectedFund,
-    final String expectedCurr,
-    final String expectedAmt,
-    final String expectedDesc,
-    final String expectedColor
-  ) {
-    final Matcher matcher = TrackService.CREATE_PATTERN.matcher(text);
-    assertThat(matcher.matches()).isEqualTo(expected);
+  @EnumSource(SortOrder.class)
+  void shouldReturnFundersSorted(final SortOrder sortOrder) {
+    when(fundService.findByName(any())).thenReturn(Optional.of(Fund.builder()
+      .id(FUND_ID)
+      .name(FUND_NAME)
+      .build()));
 
-    if (expected) {
-      assertThat(matcher.group("name")).isEqualTo(expectedFund);
-      assertThat(matcher.group("curr")).isEqualTo(expectedCurr);
-      assertThat(matcher.group("goal")).isEqualTo(expectedAmt);
-      assertThat(matcher.group("desc")).isEqualTo(expectedDesc);
-      assertThat(matcher.group("color")).isEqualTo(expectedColor);
+    when(donationStorageClient.findAll(any())).thenReturn(List.of(DONATION_1, DONATION_2));
+
+    final var result = tested.getAllFunders(FUND_NAME, sortOrder, null, null);
+
+    assertThat(result.getSize()).isEqualTo(2);
+    assertThat(result.getPage()).isZero();
+    assertThat(result.getTotal()).isEqualTo(2);
+
+    final var funder1 = Funder.fromDonation(DONATION_1);
+    final var funder2 = Funder.fromDonation(DONATION_2);
+
+    assertThat(result.getFunders()).isNotEmpty();
+
+    if (sortOrder == SortOrder.ASC) {
+      assertThat(result.getFunders()).containsExactly(funder1, funder2);
+    } else {
+      assertThat(result.getFunders()).containsExactly(funder2, funder1);
     }
   }
 
   @ParameterizedTest
   @CsvSource({
-    "'', true",
-    "fund, true",
-    "'  ', false"
+    ", , 2, , true",
+    "5, , 2, , true",
+    ", 1, 1, true, true",
+    "0, 1, 1, true, true",
+    "0, 5, 2, , true",
+    "1, 1, 1, false, true",
+    "1, 5, 0, , false",
+    "2, 1, 0, , false"
   })
-  void shouldMatchListCommand(final String text, final boolean expected) {
-    final Matcher matcher = TrackService.LIST_PATTERN.matcher(text);
-    assertThat(matcher.matches()).isEqualTo(expected);
+  void shouldReturnPagedResults(
+    final Integer page,
+    final Integer size,
+    final int expectedCnt,
+    final Boolean firstDonation,
+    final boolean hasFundersInList
+  ) {
+    when(fundService.findByName(any())).thenReturn(Optional.of(Fund.builder()
+      .id(FUND_ID)
+      .name(FUND_NAME)
+      .build()));
+
+    when(donationStorageClient.findAll(any())).thenReturn(List.of(DONATION_1, DONATION_2));
+
+    final var result = tested.getAllFunders(FUND_NAME, SortOrder.ASC, page, size);
+
+    assertThat(result.getTotal()).isEqualTo(2);
+    assertThat(result.getPage()).isEqualTo(size == null ? 0 : (page == null ? 0 : page));
+    assertThat(result.getSize()).isEqualTo(expectedCnt);
+    assertThat(result.getFunders()).hasSize(expectedCnt);
+
+    final var funder1 = Funder.fromDonation(DONATION_1);
+    final var funder2 = Funder.fromDonation(DONATION_2);
+
+    if (hasFundersInList) {
+      if (firstDonation == null) {
+        assertThat(result.getFunders()).containsExactlyInAnyOrder(funder1, funder2);
+      } else if (firstDonation) {
+        assertThat(result.getFunders()).containsOnly(funder1);
+      } else {
+        assertThat(result.getFunders()).containsOnly(funder2);
+      }
+    } else {
+      assertThat(result.getFunders()).isEmpty();
+    }
   }
-
-  @ParameterizedTest
-  @CsvSource({
-    "'', false",
-    "fund, true",
-    "'  ', false"
-  })
-  void shouldMatchDeleteCommand(final String text, final boolean expected) {
-    final Matcher matcher = TrackService.DELETE_PATTERN.matcher(text);
-    assertThat(matcher.matches()).isEqualTo(expected);
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-    "fund UAH 123, true",
-    "fund UAH 123 person, true",
-    "fund UAH 123 person 2022-05-06 12:13, true",
-    "fund UAH 123 person 12:13, true",
-    "fund UAH 123 2022-05-06 12:13, true",
-    "fund UAH 123 12:13, true",
-    "UAH 123 person, false",
-    "UAH 123, false",
-    "fund us 123, false",
-    "fund usd abc, false",
-    "fund usd123, false"
-  })
-  void shouldMatchTrackCommand(final String text, final boolean expected) {
-    final Matcher matcher = TrackService.TRACK_PATTERN.matcher(text);
-    assertThat(matcher.matches()).isEqualTo(expected);
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-    "2022-02-01 05:03, 2022-02-01T05:03:00",
-    "2022-02-01 15:13, 2022-02-01T15:13:00"
-  })
-  void shouldParseDateAndTime(final String text, final LocalDateTime expected) {
-    final var parsed = TrackService.DATE_TIME_FORMATTER.parse(text);
-    final var dateTime = LocalDateTime.from(parsed);
-
-    assertThat(dateTime).isEqualTo(expected);
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-    "05:03, 05:03:00",
-    "15:13, 15:13:00"
-  })
-  void shouldParseTimeOnly(final String text, final LocalTime expected) {
-    final var parsed = TrackService.DATE_TIME_FORMATTER_ONLY_TIME.parse(text);
-    final var time = LocalTime.from(parsed);
-
-    assertThat(time).isEqualTo(expected);
-  }
-
 }


### PR DESCRIPTION
Support page and size query params for get all funders REST.
Sort order was already supported.

Fixes #29
