### PR TITLE
feat: Save multiple donations in one request

### DIFF
--- a/src/main/java/com/yuriytkach/tracker/fundraiser/service/DonationStorageClient.java
+++ b/src/main/java/com/yuriytkach/tracker/fundraiser/service/DonationStorageClient.java
@@ -1,15 +1,12 @@
 package com.yuriytkach.tracker.fundraiser.service;
 
 import java.util.Collection;
-import java.util.Optional;
-import java.util.UUID;
 
 import com.yuriytkach.tracker.fundraiser.model.Donation;
 
 public interface DonationStorageClient {
-  void add(String fundId, Donation donation);
+  void addAll(String id, Collection<Donation> donations);
 
   Collection<Donation> findAll(String fundId);
 
-  Optional<Donation> getById(String fundId, UUID id);
 }

--- a/src/main/java/com/yuriytkach/tracker/fundraiser/service/DonationTracker.java
+++ b/src/main/java/com/yuriytkach/tracker/fundraiser/service/DonationTracker.java
@@ -1,5 +1,9 @@
 package com.yuriytkach.tracker.fundraiser.service;
 
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Set;
+
 import javax.enterprise.context.ApplicationScoped;
 
 import com.yuriytkach.tracker.fundraiser.forex.ForexService;
@@ -8,6 +12,7 @@ import com.yuriytkach.tracker.fundraiser.model.Fund;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import one.util.streamex.StreamEx;
 
 @Slf4j
 @ApplicationScoped
@@ -19,23 +24,36 @@ public class DonationTracker {
   private final DonationStorageClient donationStorageClient;
 
   public Fund trackDonation(final Fund fund, final Donation donation) {
-    log.info("Track in fund {}: {}", fund.getName(), donation);
+    return trackDonations(fund, Set.of(donation));
+  }
 
-    final int donationAmountInFund = forexService.convertCurrency(
-      donation.getAmount(), donation.getCurrency(), fund.getCurrency()
-    );
-    log.debug("Donation amount in fund currency {}: {}", fund.getCurrency(), donationAmountInFund);
+  public Fund trackDonations(final Fund fund, final Collection<Donation> donations) {
+    log.info("Track donations in fund {}: {}", fund.getName(), donations.size());
+    if (log.isDebugEnabled()) {
+      log.debug("Tracking donations: {}", donations);
+    }
+
+    final int donationAmountInFund = StreamEx.of(donations)
+      .mapToInt(donation -> forexService.convertCurrency(
+        donation.getAmount(), donation.getCurrency(), fund.getCurrency()
+      ))
+      .sum();
+    log.debug("Donations amount in fund currency {}: {}", fund.getCurrency(), donationAmountInFund);
+
+    final Instant latestDonationTime = StreamEx.of(donations)
+      .maxBy(Donation::getDateTime)
+      .map(Donation::getDateTime)
+      .orElseThrow();
 
     final Fund updatedFund = fund.toBuilder()
       .raised(fund.getRaised() + donationAmountInFund)
-      .updatedAt(donation.getDateTime())
+      .updatedAt(latestDonationTime)
       .build();
 
-    donationStorageClient.add(fund.getId(), donation);
+    donationStorageClient.addAll(fund.getId(), donations);
 
     fundService.updateFund(updatedFund);
 
     return updatedFund;
   }
-
 }


### PR DESCRIPTION
Change donation storage client to save multiple donations using single
batch write item request to dynamo db.

This will be used latest when processing multiple donations.